### PR TITLE
Add support for protobuff text + some improvements

### DIFF
--- a/Protobuf.sublime-syntax
+++ b/Protobuf.sublime-syntax
@@ -1,437 +1,453 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
+# Syntax for Protocol Buffer definition files.
+# Works with proto2 and proto3.
+# See official Protobuff documentation at https://developers.google.com/protocol-buffers/docs/proto3
+#
+# Authors: Jiarong Wei, Raul Rangel & Guillaume Wenzek
+#
+# .sublime-syntax reference: http://www.sublimetext.com/docs/3/syntax.html
 name: Protocol Buffer
 file_extensions:
   - proto
+  - protodevel
 scope: source.proto
 
+first_line_match: '^(syntax)\s*(=)\s*("proto\d")\s*(;)\s*$'
 
 variables:
-  ident: '\b[A-Za-z_][A-Za-z_0-9]*\b'
-  fullident: '(?:{{ident}}(\.))*({{ident}})'
-
-  enum: '\b(enum)\b\s*({{ident}})'
-  is_enum: '(?=\b(enum)\b\s*({{ident}}))'
-
-  message: '\b(message)\b\s*({{ident}})'
-  is_message: '(?=\b(message)\b\s*({{ident}}))'
-
-  extend: '\b(extend)\b\s*{{fullident}}'
-  is_extend: '(?=\b(extend)\b\s*{{fullident}})'
-
-  oneof: '\b(oneof)\b\s*({{ident}})'
-  is_oneof: '(?=\b(oneof)\b\s*({{ident}}))'
-
-  service: '\b(service)\b\s*({{ident}})'
-  is_service: '(?=\b(service)\b\s*({{ident}}))'
-
-  is_field_def: '(?={{fullident}}\s*{{ident}}\s*\=)'
-  is_field_def_map: '(?=\b(map<)\b)'
-
-  option_name: '(({{ident}}|(\(\.?({{ident}}\.)*{{ident}}\)))\.)*({{ident}}|(\(\.?({{ident}}\.)*{{ident}}\)))'
-
-  map_type: 'map\s*<\s*{{ident}}\s*,\s*{{ident}}\s*>'
-
+  ident: '\b([A-Za-z][A-Za-z0-9_]*)\b'
 
 contexts:
-  main:
+  prototype:
     - include: comments
+
+  main:
     - include: syntax
     - include: package
     - include: import
     - include: option
-    - match: '{{is_enum}}'
-      scope: meta.enum.proto
-      push: enum
-    - match: '{{is_message}}'
-      scope: meta.message.proto
-      push: message
-    - match: '{{is_extend}}'
-      scope: meta.extend.proto
-      push: extend
-    - match: '{{is_service}}'
-      scope: meta.service.proto
-      push: service
+    - include: enum
+    - include: message
+    - include: extend
+    - include: service
+
+    # This is proto1 syntax which is deprecated, only providing minimal support.
+    - match: '\b(parsed)?\s*((class))\s+{{ident}}\s+{'
+      scope: meta.parsed.message.proto
+      captures:
+        1: storage.type.parsed.proto
+        3: storage.type.message.proto
+        4: invalid.deprecated.class.proto
+        5: entity.name.function.proto
+      push:
+        - match: '}'
+          pop: true
+        - include: message_body
+    # Groups are deprecated, only providing minimal support.
+    - match: '\b(group)\s+(\w+)\s+=\s+(\d+)\s+{'
+      scope: meta.group.proto
+      captures:
+        1: storage.type.proto invalid.deprecated.group.proto
+        2: support.variable.proto
+        3: constant.numeric.proto
+      push:
+        - match: '}'
+          pop: true
+        - include: message_body
+
 
 # Comments
   comments:
-    - match: /\*\*/
-      scope: comment.block.empty.proto
-      captures:
-        0: punctuation.definition.comment.proto
-    - include: comments-inline
-  comments-inline:
+    - match: //
+      scope: punctuation.definition.comment.begin.proto
+      push:
+        - meta_scope: comment.line.proto
+        - match: '$'
+          pop: true
     - match: /\*
-      captures:
-        0: punctuation.definition.comment.proto
+      scope: punctuation.definition.comment.proto
       push:
         - meta_scope: comment.block.proto
         - match: \*/
-          captures:
-            0: punctuation.definition.comment.proto
+          scope: punctuation.definition.comment.proto
           pop: true
-    - match: \s*((//).*$\n?)
-      captures:
-        1: comment.line.double-slash.proto
-        2: punctuation.definition.comment.proto
+
 
 # Others
-  right-brace:
-    - match: '}'
+  or_pop:
+    # Pop when seeing unexpected characters.
+    - match: '(?=\S)'
       pop: true
-  pre-right-brace:
-    - match: '(?=\})'
+
+  field_name_or_pop:
+    - match: '{{ident}}'
+      scope: variable.other.field.proto
       pop: true
-  semicolon:
+    - include: or_pop
+
+  one_liner:
+    - match: ;
+      scope: punctuation.terminator.proto
+      pop: true
+    - match: $
+      pop: true
+
+  semicolon_or_pop:
     - match: ';'
       captures:
         0: punctuation.terminator.proto
       pop: true
-  operator-assignment:
+    - include: or_pop
+
+  assignment_or_pop:
     - match: '='
       scope: keyword.operator.assignment.proto
+      pop: true
+    - include: or_pop
 
 
 # Syntax
   syntax:
-    - match: '\b(syntax)\b\s*(?=\=)'
+    - match: '^\s*(syntax)\s*(=)'
       captures:
-        1: keyword.control.proto
+        1: keyword.other.syntax.proto
+        2: keyword.operator.assignment.proto
       push:
-        - include: operator-assignment
-        - match: '\"proto[23]\"'
-          scope: string.quoted.double.proto
-        - include: semicolon
+        - include: string
+        - include: one_liner
 
 
 # Import
   import:
-    - match: '\b(import)\b'
-      scope: keyword.source.proto
+    - match: '\b(import)\b\s*(weak|public)?\b'
+      captures:
+        1: keyword.other.import.proto
+        2: storage.modifier.proto
       push:
-        - match: '\b(public)\b'
-          scope: keyword.control.proto
-        - include: strings
-        - include: semicolon
+        - include: string
+        - include: one_liner
 
 
 # Package
   package:
-    - match: '\b(package)\b'
-      captures:
-        1: keyword.control.proto
+    - match: \b(package)\b
+      scope: keyword.other.namespace.proto
       push:
-        - match: '{{fullident}}'
-          scope: storage.modifier.package.proto
-        - include: semicolon
+        - match: '{{ident}}(\.)'
+          captures:
+            1: variable.namespace.proto
+            2: punctuation.separator.namespace.proto
+        - match: '{{ident}}'
+          scope: entity.name.namespace.proto
+        - include: one_liner
 
 
 # Option
   option:
     - match: '\b(option)\b'
-      scope: keyword.control.proto
+      scope: keyword.other.option.proto
       push:
-        - match: '({{option_name}})\s*(?=\=)'
-          captures:
-            1: variable.parameter.proto
-        - include: operator-assignment
-        - include: values
-        - include: semicolon
-        - include: option-uninterpreted-block
-  option-uninterpreted-block:
-    - match: '{'
-      push: option-uninterpreted-block
-    - include: right-brace
+        - match: ';'
+          scope: punctuation.terminator.option.proto
+          pop: true
+        - include: option_inline
+        - include: or_pop
 
-
-  field-label:
-    - match: '\b(repeated|optional|required)\b'
-      captures:
-        1: storage.modifier.proto
-
-  field-definition:
-    - match: '({{ident}})\s*(?=\=)'
-      captures:
-        1: variable.other.proto
-    - include: all-types
-    - include: operator-assignment
-    - include: constants-numeric
-    - match: '\['
-      push: field-option
-    - include: semicolon
-    - match: '{'
-      push:
-        - include: field-group
-        - include: pre-right-brace
-    - include: right-brace
-
-  field-option:
-    - match: '({{option_name}})\s*(?=\=)'
-      captures:
-        1: variable.parameter.proto
-    - match: '='
+  option_inline:
+    - match: '{{ident}}'
+      scope: variable.annotation.proto
+    - include: full_option_name
+    - match: =
       scope: keyword.operator.assignment.proto
+      push: option_value
+
+  full_option_name:
+    - match: \(
+      scope: punctuation.definition.name.option.begin.proto
       push:
-      - match: '{{ident}}'
-        scope: constant.other.proto
-      - include: values
-      - match: '(?=\])'
-        pop: true
-    - include: option-uninterpreted-block
-    - match: '\]'
-      pop: true
-  
-  field-group:
-    - include: field-label
-    - match: '{{is_field_def}}'
-      push: field-definition
+        - match: (\))(?:(\.){{ident}})?
+          captures:
+            1: punctuation.definition.name.option.end.proto
+            2: punctuation.accessor.proto
+            3: variable.annotation.proto
+          pop: true
+        - match: '{{ident}}(\.)'
+          captures:
+            1: variable.namespace.proto
+            2: punctuation.accessor.proto
+        - match: '{{ident}}'
+          scope: variable.annotation.proto
 
 
 # Message
   message:
-    - match: '{{message}}'
+    - match: '\b(message)\b\s*{{ident}}'
+      captures:
+        1: storage.modifier.message.proto
+        2: entity.name.class.proto
+      push:
+        - meta_scope: meta.class.proto
+        - match: '{'
+          scope: punctuation.definition.block.message.begin.proto
+          set: message_body
+        - include: or_pop
+
+  message_body:
+    - meta_scope: meta.class.proto
+    - match: '}'
+      scope: punctuation.definition.block.message.end.proto
+      pop: true
+    - include: option
+    - include: message
+    - include: extend
+    - include: oneof
+    - include: enum
+    - include: reserved
+    - include: field
+
+  field:
+    - match: '\b(optional|required|repeated)\b'
       captures:
         1: storage.modifier.proto
-        2: entity.name.type.message.proto
-    - match: '{'
-      push:
-        - meta_scope: meta.message.body.proto
-        - include: message-body
-        - include: pre-right-brace
-    - include: right-brace
-  message-body:
-    - include: comments
-    - match: '{{is_enum}}'
-      scope: meta.enum.proto
-      push: enum
-    - match: '{{is_message}}'
-      scope: meta.message.proto
-      push: message
-    - match: '{{is_extend}}'
-      scope: meta.extend.proto
-      push: extend
-    - match: '{{is_oneof}}'
-      scope: meta.oneof.proto
-      push: oneof
-    - include: reserved
-    - include: extensions
-    - include: option
-    - include: field-label
-    - match: '{{is_field_def}}'
-      push: field-definition
-    - match: '{{is_field_def_map}}'
-      push: field-definition
-
+      push: [ field_end_or_pop, field_name_or_pop, message_type_or_pop ]
+    - match: '\b(map)\b\s*\b(<)'
+      captures:
+        1: support.type.map.proto
+        2: punctuation.definition.map.begin.proto
+      push: [ field_end_or_pop, field_name_or_pop, map_type ]
+    # field are assumed 'optional' by default in proto3.
+    - match: '(?={{ident}})'
+      push: [ field_end_or_pop, field_name_or_pop, message_type_or_pop ]
 
 # Enum
   enum:
-    - match: '{{enum}}'
+    - match: '\b(enum)\b\s*{{ident}}'
       captures:
-        1: storage.modifier.proto
-        2: entity.name.type.enum.proto
-    - match: '{'
+        1: storage.modifier.enum.proto
+        2: entity.name.enum.proto
       push:
-        - meta_scope: meta.enum.body.proto
-        - include: enum-body
-        - include: pre-right-brace
-    - include: right-brace
-  enum-body:
-    - include: comments
-    - match: '{{is_enum}}'
-      scope: meta.enum.proto
-      push: enum
+        - meta_scope: meta.enum.proto
+        - match: '{'
+          scope: punctuation.definition.block.enum.begin.proto
+          set: enum_body
+        - include: or_pop
+
+  enum_body:
+    - meta_scope: meta.enum.proto
+    - match: '}'
+      scope: punctuation.definition.block.enum.end.proto
+      pop: true
     - include: option
-    - match: '(?={{ident}}\s*\=)'
-      push: enum-field
-  enum-field:
-    - match: '({{ident}})\s*(?=\=)'
-      captures:
-        1: constant.language.proto
-    - include: operator-assignment
-    - include: constants-numeric
-    - include: semicolon
+    - match: '{{ident}}'
+      scope: constant.other.enum.proto
+      push:
+        - semicolon_or_pop
+        - field_attributes_or_pop
+        - number_or_pop
+        - assignment_or_pop
 
 
 # Extend
   extend:
-    - match: '{{extend}}'
-      captures:
-        1: storage.modifier.proto
-        3: entity.name.type.extend.proto
+    - match: '\b(extend)\b'
+      scope: storage.modifier.extend.proto
+      push: [ extend_body_or_pop, message_type_or_pop]
+
+  extend_body_or_pop:
     - match: '{'
-      push:
+      scope: punctuation.definition.block.extend.begin.proto
+      set:
         - meta_scope: meta.extend.body.proto
-        - include: extend-body
-        - include: pre-right-brace
-    - include: right-brace
-  extend-body:
-    - include: comments
-    - include: field-label
-    - match: '{{is_field_def}}'
-      push: field-definition
+        - match: '}'
+          scope: punctuation.definition.block.extend.end.proto
+          pop: true
+        - include: message_body
+    - include: or_pop
 
 
 # Oneof
   oneof:
-    - match: '{{oneof}}'
+    - match: '\b(oneof)\b\s*{{ident}}'
       captures:
-        1: storage.modifier.proto
-        2: entity.name.type.oneof.proto
-    - match: '{'
+        1: storage.modifier.oneof.proto
+        2: entity.name.member.proto
       push:
-        - meta_scope: meta.oneof.body.proto
-        - include: oneof-body
-        - include: pre-right-brace
-    - include: right-brace
-  oneof-body:
-    - include: comments
-    - match: '{{is_field_def}}'
-      push: field-definition
+        - meta_scope: meta.oneof.proto
+        - match: '{'
+          scope: punctuation.definition.block.oneof.begin.proto
+          set: oneof_body
+        - include: or_pop
+
+  oneof_body:
+    - match: '}'
+      scope: punctuation.definition.block.oneof.end.proto
+      pop: true
+    - match: '(?=\S)'
+      push: [ field_end_or_pop, field_name_or_pop, message_type_or_pop ]
 
 
 # Service
   service:
-    - match: '{{service}}'
+    - match: '\b(service)\b\s*{{ident}}'
       captures:
-        1: storage.modifier.proto
-        2: entity.name.type.service.proto
-    - match: '{'
+        1: storage.modifier.service.proto
+        2: entity.name.class.proto
       push:
-        - meta_scope: meta.service.body.proto
-        - include: service-body
-        - include: pre-right-brace
-    - include: right-brace
-  service-body:
-    - include: comments
-    - match: '(?=\b(rpc)\b\s+({{ident}})\s*\()'
-      push: rpc
+        - meta_scope: meta.service.proto
+        - match: '{'
+          scope: punctuation.definition.block.service.begin.proto
+          set:
+            - meta_scope: meta.service.proto
+            - match: '}'
+              scope: punctuation.definition.block.service.end.proto
+              pop: true
+            - include: option
+            - include: rpc
+        - include: or_pop
 
 
 # Rpc
   rpc:
-    - match: '\b(rpc)\b\s+({{fullident}})\s*(?=\()'
+    - match: '\b(rpc)\b\s*{{ident}}'
       captures:
-        1: keyword.control.proto
-        2: entity.name.function.proto
-    - match: '\('
-      push:
-        - include: rpc-parameter
-    - match: '\b(returns)\b'
-      scope: keyword.control.proto
-    - include: semicolon
-    - match: '{'
-      push:
-        - include: rpc-body
-        - include: pre-right-brace
-    - include: right-brace
-  
-  rpc-parameter:
-    - match: '(\b(?:stream)\b)?\s*{{fullident}}'
-      captures:
-        1: storage.modifier.proto
-        3: storage.type.proto
-    - match: '\)'
+        1: storage.modifier.rpc.proto
+        2: entity.name.function.rpc.proto
+      push: [rpc_body, rpc_param, rpc_returns, rpc_param]
+
+  rpc_returns:
+    - match: returns
+      scope: keyword.other.returns.proto
       pop: true
 
-  rpc-body:
-    - include: option
+  rpc_param:
+    - match: \(
+      scope: punctuation.definition.parameter.rpc.begin.proto
+      set:
+        - match: \)
+          scope: punctuation.definition.parameter.rpc.end.proto
+          pop: true
+        - match: '\bstream\b'
+          scope: storage.modifier.proto
+        - match: (?=\S)
+          push: message_type_or_pop
+
+  rpc_body:
+    - match: '{'
+      scope: punctuation.definition.block.rpc.begin.proto
+      set:
+        - meta_scope: meta.rpc.body.proto
+        - match: '}'
+          scope: punctuation.definition.block.rpc.end.proto
+          pop: true
+        - include: option
+    - match: ;
+      scope: punctuation.terminator.proto
+      pop: true
+    - include: or_pop
 
 
 # Reserved
   reserved:
-    - match: '\b(reserved)\b'
-      captures:
-        1: storage.modifier.proto
+    - match: '\b(reserved|extensions)\b'
+      scope: storage.modifier.proto
       push:
-        - match: '\b(to)\b'
-          scope: keyword.operator.proto
-        - include: strings
-        - include: constants-numeric
-        - include: semicolon
+        - match: \d+
+          scope: constant.numeric.proto
+        - match: max
+          scope: constant.language.proto
+        - match: ','
+          scope: punctuation.separator.proto
+        - match: to
+          scope: keyword.other.to.proto
+        - match: ';'
+          scope: punctuation.terminator.proto
+          pop: true
 
-# Extensions
-  extensions:
-    - match: '\b(extensions)\b'
-      captures:
-        1: storage.modifier.proto
-      push:
-        - match: '\b(to)\b'
-          scope: keyword.operator.proto
-        - include: constants
-        - include: semicolon
+  field_end_or_pop:
+    - match: ''
+      set:
+        - semicolon_or_pop
+        - field_attributes_or_pop
+        - number_or_pop
+        - assignment_or_pop
+
+  field_attributes_or_pop:
+    - match: '\['
+      scope: punctuation.definition.attributes.begin.proto
+      set:
+        - meta_scope: meta.field.attributes.proto
+        - match: \b(default|deprecated|packed)\b
+          scope: support.function.proto
+        - match: \,
+          scope: punctuation.separator.option.proto
+        - match: '\]'
+          scope: punctuation.definition.attributes.end.proto
+          pop: true
+        - include: option_inline
+    - include: or_pop
 
 
 # Values
-  values:
-    - include: strings
-    - include: constants
+  option_value:
+    # Reuse prototxt syntax to parse embedded literal or protos.
+    - match: '{'
+      scope: punctuation.definition.block.option.begin.proto
+      push:
+        - meta_scope: meta.embedded.prototxt
+        - match: '}'
+          scope: punctuation.definition.block.option.end.proto
+          pop: true
+        - include: scope:text.prototxt
+    - include: scope:text.prototxt#field_value_or_pop
 
-  constants:
-    - include: constants-alpha
-    - include: constants-numeric
-    - include: constants-others
-  constants-alpha:
-    - match: \b(true|false|max)\b
-      scope: constant.language.proto
-  constants-numeric:
-    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b'
+  number_or_pop:
+    - match: \d+
       scope: constant.numeric.proto
-  constants-others:
-    - match: '(\.)?\b([A-Z][A-Z0-9_]+)(?!<|\s*\w+\s*=)\b'
-      scope: constant.other.proto
-      captures:
-        1: keyword.operator.dereference.proto
+      pop: true
+    - include: or_pop
 
-  strings:
+  string:
     - match: '"'
-      captures:
-        0: punctuation.definition.string.begin.proto
+      scope: punctuation.definition.string.begin.proto
       push:
         - meta_scope: string.quoted.double.proto
+        - meta_include_prototype: false
+        - match: '\\"'
+          scope: constant.character.escape.proto
         - match: '"'
-          captures:
-            0: punctuation.definition.string.end.proto
+          scope: punctuation.definition.string.end.proto
           pop: true
-        - match: \\.
-          scope: constant.character.escape.proto
-    - match: "'"
-      captures:
-        0: punctuation.definition.string.begin.proto
-      push:
-        - meta_scope: string.quoted.single.proto
-        - match: "'"
-          captures:
-            0: punctuation.definition.string.end.proto
+        - match: (?=$) # pop if string is malformed.
           pop: true
-        - match: \\.
-          scope: constant.character.escape.proto
 
 
 # All types
-  all-types:
-    - include: object-types
-    - include: primitive-types
-
-  object-types:
-    - include: map-type
-    - match: '{{fullident}}'
+  message_type_or_pop:
+    # see documentation for the list of base types:
+    # https://developers.google.com/protocol-buffers/docs/proto#scalar
+    - match: '(double|float|bool|string|bytes)'
+      scope: support.type.proto
+      pop: true
+    - match: '(u|s)?int(32|64)'
+      scope: support.type.proto
+      pop: true
+    - match: 's?fixed(32|64)'
+      scope: support.type.proto
+      pop: true
+    - match: '{{ident}}(\.)'
       captures:
-        2: storage.type.proto
+        1: variable.namespace.proto
+        2: punctuation.accessor.proto
+    - match: '{{ident}}'
+      scope: variable.type.proto
+      pop: true
 
-  map-type:
-    - match: '\b(map<)\b'
-      push:
-        - meta_scope: storage.type.generic.proto
-        - match: '>'
-          pop: true
-        - include: object-types
-        - match: '<'
-          push:
-            - meta_scope: storage.type.generic.proto
-            - match: '>|[^\w\s,\[\]<]'
-              pop: true
- 
-  primitive-types:
-    - match: \b(double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64|bool|string|bytes)\b
-      scope: storage.type.primitive.proto
+  map_type:
+    - match: ','
+      scope: punctuation.separator.map.proto
+    - match: '>'
+      scope: punctuation.definition.map.end.proto
+      pop: true
+    - match: '(?={{ident}})'
+      push: message_type_or_pop

--- a/ProtobufText.sublime-syntax
+++ b/ProtobufText.sublime-syntax
@@ -1,0 +1,186 @@
+%YAML 1.2
+---
+# Syntax for Protocol Buffer serialized as human readable text.
+# Works with proto2 and proto3.
+# See official Protobuff documentation at https://developers.google.com/protocol-buffers/docs/proto3
+#
+# Author: Raul Rangel & Guillaume Wenzek
+#
+# .sublime-syntax reference: http://www.sublimetext.com/docs/3/syntax.html
+name: Protocol Buffer (TEXT)
+file_extensions:
+  - pb.txt
+  - proto.text
+  - textpb
+  - pbtxt
+  - prototxt
+scope: text.prototxt
+variables:
+  stringEscape: '(?:\\(?:[''"\\/abfnrtv?]|[0-9]{3}|(?i:u|x)[0-9A-Fa-f]+))'
+  field_name: '\b([A-Za-z][A-Za-z0-9_]*)\b'
+  integer: '(?:\+|-)?(?:0|[1-9]\d*)'
+  exp: '(?i:e(?:\+|-)?{{integer}})'
+
+contexts:
+  prototype:
+    - include: comments
+
+  or_pop:
+    # Pop if nothing matched (whitespace are ignored).
+    - match: '(?=\S)'
+      pop: true
+
+  main:
+    - include: field
+
+  comments:
+    - match: '#'
+      scope: punctuation.definition.comment.begin.prototxt
+      push:
+        - meta_scope: comment.line.prototxt
+        - match: '$'
+          pop: true
+
+  field:
+    - match: '{{field_name}}'
+      scope: variable.other.member.prototxt
+      push: field_sep_or_pop
+    - match: \[
+      scope: punctuation.definition.field_name.begin.prototxt
+      push:
+        - match: \]
+          set: field_sep_or_pop
+          scope: punctuation.definition.field_name.end.prototxt
+        - match: '{{field_name}}(\.)'
+          captures:
+            1: variable.other.namespace.prototxt
+            2: punctuation.accessor.prototxt
+        - match: '{{field_name}}'
+          scope: variable.other.member.prototxt
+
+  field_sep_or_pop:
+    - match: '(:)|(?=\{|<)'
+      scope: punctuation.separator.key-value.prototxt
+      set: [comma_or_pop, field_value_or_pop]
+    - include: or_pop
+
+  field_value_or_pop:
+    - match: '{'
+      scope: punctuation.definition.dictionary.begin.prototxt
+      set:
+        - meta_scope: meta.message.prototxt
+        - match: '}'
+          scope: punctuation.definition.dictionary.end.prototxt
+          pop: true
+        - include: field
+    - match: '<'
+      scope: punctuation.definition.dictionary.begin.prototxt
+      set:
+        - meta_scope: meta.message.prototxt
+        - match: '>'
+          scope: punctuation.definition.dictionary.end.prototxt
+          pop: true
+        - include: field
+    - include: constant
+    - include: string_double_multiline
+    - include: string_single_multiline
+    - include: enum_value
+    - include: number
+    - include: array
+    - include: or_pop
+
+  array:
+    - match: '\['
+      scope: punctuation.definition.array.begin.prototxt
+      set:
+        - match: '\]'
+          scope: punctuation.definition.array.end.prototxt
+          pop: true
+        - match: \,
+          scope: punctuation.separator.array.prototxt
+        - match: (?=\S)
+          push: field_value_or_pop
+
+  comma_or_pop:
+    - match: ','
+      scope: punctuation.separator.prototxt
+      pop: true
+    - include: or_pop
+
+  constant:
+    - match: \b(true|True|t|false|False|f)\b
+      scope: constant.language.prototxt
+      pop: true
+    - match: (\+|-)?\b(?i:inf|infinity)\b
+      scope: constant.language.prototxt
+      pop: true
+    - match: \b(?i:nan)\b
+      scope: constant.language.prototxt
+      pop: true
+
+  number:
+    - match: |-
+        (?xi:
+          {{integer}}?\.\d+{{exp}}?(f?)  # literal with a dot: .3 .3e+4 1.3 1.3f
+          |{{integer}}(f)                # literal with a 'f': 1f
+          |{{integer}}{{exp}}(f?)        # literal with an exp: .3e+4 1e-3 1e3f
+        )\b
+      scope: constant.numeric.float.prototxt
+      captures:
+        1: punctuation.definition.numeric.float.prototxt
+        2: punctuation.definition.numeric.float.prototxt
+        3: punctuation.definition.numeric.float.prototxt
+      pop: true
+    - match: '{{integer}}\b'
+      scope: constant.numeric.integer.prototxt
+      pop: true
+    - match: '(0)[0-8]+\b'
+      scope: constant.numeric.octal.prototxt
+      captures:
+        1: punctuation.definition.numeric.octal.prototxt
+      pop: true
+    - match: '(0[xX])[0-9A-Fa-f]+\b'
+      scope: constant.numeric.hex.prototxt
+      captures:
+        1: punctuation.definition.numeric.hex.prototxt
+      pop: true
+
+  enum_value:
+    - match: '{{field_name}}'
+      scope: constant.numeric.enum.prototxt
+      pop: true
+
+  string_double_multiline:
+    - match: '"'
+      scope: punctuation.definition.string.begin.prototxt
+      set:
+        - meta_scope: string.quoted.double.prototxt
+        - meta_include_prototype: false
+        - match: '{{stringEscape}}'
+          scope: constant.character.escape.prototxt
+        - match: \\.
+          scope: invalid.illegal.unrecognized-string-escape.prototxt
+        - match: '"'
+          scope: punctuation.definition.string.end.prototxt
+          set:
+            - include: string_double_multiline
+            - include: or_pop
+
+  string_single_multiline:
+    - match: "'"
+      scope: punctuation.definition.string.quoted.single.begin.prototxt
+      set:
+        - meta_scope: string.quoted.single.prototxt
+        - meta_include_prototype: false
+        # Note that technically "bytes" field main don't respect escapes,
+        # but there is no way to know if the given string will be interpreted as
+        # "bytes".
+        - match: '{{stringEscape}}'
+          scope: constant.character.escape.prototxt
+        - match: \\.
+          scope: invalid.illegal.unrecognized-string-escape.prototxt
+        - match: "'"
+          scope: punctuation.definition.string.quoted.single.end.prototxt
+          set:
+            - include: string_single_multiline
+            - include: or_pop

--- a/ProtobufTextComments.YAML-tmPreferences
+++ b/ProtobufTextComments.YAML-tmPreferences
@@ -1,0 +1,8 @@
+# [PackageDev] target_format: plist, ext: tmPreferences
+name: Comments
+uuid: 3774f180-135c-11e9-ab14-d663bd873d93
+scope: text.prototxt
+settings:
+  shellVariables:
+  - name: TM_COMMENT_START
+    value: '# '

--- a/ProtobufTextComments.tmPreferences
+++ b/ProtobufTextComments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>text.prototxt</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>3774f180-135c-11e9-ab14-d663bd873d93</string>
+</dict>
+</plist>

--- a/tests/syntax_test_pbtxt.pbtxt
+++ b/tests/syntax_test_pbtxt.pbtxt
@@ -16,6 +16,7 @@ health: 1e+2
 #       ^^^^ constant.numeric.float.prototxt
 xp: 4200   # normal digit
 #   ^^^^ constant.numeric.integer.prototxt
+#            ^^^^^^^^^^^^ comment.line.prototxt
 xp: 04200  # octal
 #   ^^^^^ constant.numeric.octal.prototxt
 #   ^ punctuation.definition.numeric.octal.prototxt

--- a/tests/syntax_test_pbtxt.pbtxt
+++ b/tests/syntax_test_pbtxt.pbtxt
@@ -1,0 +1,108 @@
+# SYNTAX TEST "ProtobufText.sublime-syntax"
+
+name: "player_1"
+# <- variable.other.member.prototxt
+#   ^ punctuation.separator.key-value.prototxt
+#     ^ string.quoted.double.prototxt punctuation.definition.string.begin.prototxt
+#      ^^^^^^^^ string.quoted.double.prototxt
+health: 100.0
+# <- variable.other.member.prototxt
+#     ^ punctuation.separator.key-value.prototxt
+#       ^^^^^ constant.numeric.float.prototxt
+health: 100f
+#       ^^^^ constant.numeric.float.prototxt
+#          ^ punctuation.definition.numeric.float.prototxt
+health: 1e+2
+#       ^^^^ constant.numeric.float.prototxt
+xp: 4200   # normal digit
+#   ^^^^ constant.numeric.integer.prototxt
+xp: 04200  # octal
+#   ^^^^^ constant.numeric.octal.prototxt
+#   ^ punctuation.definition.numeric.octal.prototxt
+xp: 0xFFFF # hex
+#   ^^^^^^ constant.numeric.hex.prototxt
+#   ^^ punctuation.definition.numeric.hex.prototxt
+xp: -24
+#   ^^^ constant.numeric.integer.prototxt
+xp: +24
+#   ^^^ constant.numeric.integer.prototxt
+xp: 0
+#   ^ constant.numeric.integer.prototxt
+xp: +Inf
+#   ^^^^ constant.language.prototxt
+xp: NaN
+#   ^^^ constant.language.prototxt
+
+stats {
+# <- variable.other.member.prototxt
+#     ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
+  key: "STR"
+  value {
+    id: "STR"
+    max_value: 100
+    # <- meta.message.prototxt meta.message.prototxt variable.other.member.prototxt
+  }
+# ^ meta.message.prototxt meta.message.prototxt punctuation.definition.dictionary.end.prototxt
+}
+# <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt
+
+stats <
+# <- variable.other.member.prototxt
+#     ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
+  key: "INT"
+  value <
+    # <- variable.other.member.prototxt
+    #   ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
+    id: "INT"
+    max_value: 20
+  >
+# ^ punctuation.definition.dictionary.end.prototxt
+>
+# <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt
+
+buffs: [BURNING, POISONED]
+# <- variable.other.member.prototxt
+#    ^ punctuation.separator.key-value.prototxt
+#      ^ punctuation.definition.array.begin.prototxt
+#       ^^^^^^^ constant.numeric.enum.prototxt
+#                ^^^^^^^^ constant.numeric.enum.prototxt
+#                        ^ punctuation.definition.array.end.prototxt
+avatar: "aaabbb\nccc\c"
+#       ^^^^^^^^^^^^^^^ string.quoted.double.prototxt
+#              ^^ constant.character.escape.prototxt
+#                   ^^ invalid.illegal
+        "dddddddd"
+#       ^^^^^^^^^^ string.quoted.double.prototxt
+
+escaped_chars: "\x12  \" \' \u124"
+#               ^^^^ constant.character.escape.prototxt
+#                     ^^ constant.character.escape.prototxt
+#                        ^^ constant.character.escape.prototxt
+#                           ^^^^^ constant.character.escape.prototxt
+
+name: "Conan", name: "The barbar"
+#            ^ punctuation.separator.prototxt
+#              ^^^^ variable.other.member.prototxt
+alive: true
+
+[extension.field]: 20
+# <- punctuation.definition.field_name.begin.prototxt
+#^^^^^^^^^ variable.other.namespace.prototxt
+#         ^ punctuation.accessor.prototxt
+#          ^^^^^ variable.other.member.prototxt
+#               ^ punctuation.definition.field_name.end.prototxt
+#                ^ punctuation.separator.key-value.prototxt
+#                  ^^ constant.numeric.integer.prototxt
+
+[extension.field_message] {
+# <- punctuation.definition.field_name.begin.prototxt
+#^^^^^^^^^ variable.other.namespace.prototxt
+#         ^ punctuation.accessor.prototxt
+#          ^^^^^^^^^^^^^ variable.other.member.prototxt
+#                       ^ punctuation.definition.field_name.end.prototxt
+#                         ^ meta.message.prototxt punctuation.definition.dictionary.begin.prototxt
+
+  value: 20
+#        ^^ constant.numeric.integer.prototxt
+}
+# <- meta.message.prototxt punctuation.definition.dictionary.end.prototxt

--- a/tests/syntax_test_proto2.proto
+++ b/tests/syntax_test_proto2.proto
@@ -56,13 +56,19 @@ message Player {
   //      ^^^^^^^^^^^^^^^^^^^^ variable.other.field.proto
 
   reserved 42;
-  // <- storage.modifier.reserved.proto
+  // <- storage.modifier.proto
   //       ^^ constant.numeric.proto
   reserved 100 to 200;
-  // <- storage.modifier.reserved.proto
+  // <- storage.modifier.proto
   //       ^^^ constant.numeric.proto
   //           ^^ keyword.other.to.proto
   //              ^^^ constant.numeric.proto
+
+  extensions 10000 to max;
+  // <- storage.modifier.proto
+  //         ^^^^^ constant.numeric.proto
+  //               ^^ keyword.other.to.proto
+  //                  ^^^ constant.language.proto
 
   // Stats describing the user characteristic (Strenght, Intelligence, ...).
   // <- comment.line.proto punctuation.definition.comment.begin.proto
@@ -124,6 +130,7 @@ enum Buff {
   //                   ^^^^ constant.language
 
   NO_BUFF = 0;
+  // <- constant.other.enum.proto
   FROZEN = 1;
   BURNING = 2;
   POISONED = 2 [(doc) = "Poisoned by a magic weapon."];

--- a/tests/syntax_test_proto2.proto
+++ b/tests/syntax_test_proto2.proto
@@ -1,0 +1,175 @@
+// SYNTAX TEST "Protobuf.sublime-syntax"
+syntax = "proto2";
+// <- keyword.other.syntax.proto
+//        ^^^^^^ string.quoted.double.proto
+
+package escape_dungeon;
+// <- keyword.other.namespace.proto
+//      ^^^^^^^^^^^^^^ entity.name.namespace.proto
+
+import "escape_dungeon/weapons.proto";
+// <- keyword.other.import.proto
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.proto
+
+option java_package = "com.example.foo";
+// <- keyword.other.option.proto
+//     ^^^^^^^^^^^^ variable.annotation.proto
+//                  ^ keyword.operator.assignment.proto
+//                    ^^^^^^^^^^^^^^^^^ string
+
+message Player {
+// <- meta.class.proto storage.modifier.message.proto
+//      ^^^^^^ entity.name.class.proto
+
+  required string name = 1;
+  // ^^^^^ storage.modifier.proto
+  //       ^^^^^^ support.type.proto
+  //              ^^^^ variable.other.field.proto
+  //                   ^ keyword.operator.assignment.proto
+  //                     ^ constant.numeric.proto
+  //                      ^ punctuation.terminator.proto
+  optional float health = 2;
+  //       ^^^^^ support.type.proto
+
+  optional uint64 xp = 3;
+  //       ^^^^^^ support.type.proto
+
+  map<string, Stats> stats = 4;
+  // <- support.type.map.proto
+  //  ^^^^^^ support.type.proto
+  //          ^^^^^ variable.type.proto
+  //                 ^^^^^ variable.other.field.proto
+  repeated Buff buffs = 5;
+  repeated escape_dungeon.Weapon weapons = 6;
+  optional bytes avatar = 7;
+  //       ^^^^^ support.type.proto
+
+  optional bool alive = 8;
+  //       ^^^^ support.type.proto
+
+  optional
+  // ^^^^^ storage.modifier.proto
+      very_long_namespace_name.VeryLongMessageType
+  //  ^^^^^^^^^^^^^^^^^^^^^^^^ variable.namespace.proto
+  //                           ^^^^^^^^^^^^^^^^^^^ meta.class.proto variable.type.proto
+          very_long_field_name = 9;
+  //      ^^^^^^^^^^^^^^^^^^^^ variable.other.field.proto
+
+  reserved 42;
+  // <- storage.modifier.reserved.proto
+  //       ^^ constant.numeric.proto
+  reserved 100 to 200;
+  // <- storage.modifier.reserved.proto
+  //       ^^^ constant.numeric.proto
+  //           ^^ keyword.other.to.proto
+  //              ^^^ constant.numeric.proto
+
+  // Stats describing the user characteristic (Strenght, Intelligence, ...).
+  // <- comment.line.proto punctuation.definition.comment.begin.proto
+  message Stats {
+  // <- meta.class.proto meta.class.proto storage.modifier.message.proto
+    required string id = 1;
+    // <- storage.modifier.proto
+    optional int32 max_value = 2;
+    optional int32 value = 3 [(custom.annotation) = -1];
+    //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.field.attributes.proto
+    //                         ^^^^^^ variable.namespace.proto
+    //                                ^^^^^^^^^^ variable.annotation.proto
+    //                                              ^^ constant.numeric
+  }
+
+// <- meta.class.proto -(meta.class.proto meta.class.proto)
+}
+
+// <- - meta.class.proto
+
+message Config {
+  oneof config {
+    StatConfig stat = 1;
+    LevelConfig level = 2;
+    WeaponConfig weapon = 3;
+  }
+}
+
+message LevelConfig {
+  optional int32 max_level = 1 [default = 100];
+  //                            ^^^^^^^ support.function.proto
+  //                                      ^^^ constant.numeric
+  repeated uint64 xp_levels = 2 [packed=true];
+  //                             ^^^^^^ support.function.proto
+  //                                    ^^^^ constant.language
+  optional int32 min_level = 3 [(str.option)="important", (another)="foo"];
+  //                             ^^^ variable.namespace.proto
+  //                                 ^^^^^^ variable.annotation.proto
+  //                                         ^^^^^^^^^^^ string.quoted
+  //                                                       ^^^^^^^ variable.annotation.proto
+  optional int32 another_value = 4 [proto={ enum: FROZEN }];
+  //                                      ^^^^^^^^^^^^^^^^ meta.embedded.prototxt
+  //                                        ^^^^ variable.other.member.prototxt
+  //                                              ^^^^^^ meta.embedded.prototxt constant.numeric.enum.prototxt
+  optional int32 another_value = 4 [proto={ nested {} enum: FROZEN }];
+  //                                               ^^ meta.embedded.prototxt
+  optional int32 another_value = 4 [unset=];
+  //                                      ^ punctuation.definition.attributes.end.proto
+}
+
+enum Buff {
+// <- meta.enum.proto storage.modifier.enum.proto
+//   ^^^^ entity.name.enum.proto
+
+  option allow_alias = true;
+  // <- keyword.other.option.proto
+  //     ^^^^^^^^^^^ variable.annotation.proto
+  //                 ^ keyword.operator.assignment.proto
+  //                   ^^^^ constant.language
+
+  NO_BUFF = 0;
+  FROZEN = 1;
+  BURNING = 2;
+  POISONED = 2 [(doc) = "Poisoned by a magic weapon."];
+  INVALID == 2;
+  //       ^ -keyword
+  //         ^ -constant
+}
+
+service PlayerService {
+// <- meta.service.proto storage.modifier.service.proto
+  rpc GetPlayer (PlayerRequest) returns (PlayerResponse);
+  // <- storage.modifier.rpc.proto
+  //  ^^^^^^^^^ entity.name.function.rpc.proto
+  //             ^^^^^^^^^^^^^ variable.type.proto
+  //                            ^^^^^^^ keyword.other.returns.proto
+  //                                    ^ punctuation.definition.parameter.rpc.begin.proto
+  //                                     ^^^^^^^^^^^^^^ variable.type.proto
+  //                                                   ^ punctuation.definition.parameter.rpc.end.proto
+
+  rpc GetAllPlayers(AllPlayersRequest) returns (stream PlayerResponse) {
+  // <- storage.modifier.rpc.proto
+  //  ^^^^^^^^^^^^^ entity.name.function.rpc.proto
+  //                ^^^^^^^^^^^^^^^^^ variable.type.proto
+  //                                   ^^^^^^^ keyword.other
+  //                                            ^^^^^^ storage.modifier
+  //                                                   ^^^^^^^^^^^^^^ variable.type.proto
+    option security_label = "read";
+    // <- meta.service.proto meta.rpc.body.proto
+    //     ^^^^^^^^^^^^^^ meta.service.proto meta.rpc.body.proto variable.annotation.proto
+    //                    ^ meta.service.proto meta.rpc.body.proto keyword.operator.assignment.proto
+    //                      ^^^^^^ meta.service.proto meta.rpc.body.proto string.quoted.double.prototxt
+    //                            ^ meta.service.proto meta.rpc.body.proto punctuation.terminator.option.proto
+    option deadline = 5.0;
+    // <- keyword.other.option.proto
+    //     ^^^^^^^^ variable.annotation.proto
+    //              ^ keyword.operator.assignment.proto
+    //                ^^^ constant.numeric.float.prototxt
+    //                   ^ punctuation.terminator.option.proto
+    option (method_doc) =
+    // <- keyword.other.option.proto
+    //      ^^^^^^^^^^ variable.annotation.proto
+    //                  ^ keyword.operator.assignment.proto
+        "Returns all the player."
+        "This documentation doesn't fit in one line,"
+        "nor in two.";
+    //   ^^^^^^^^^^^ string.quoted.double.prototxt
+    //               ^ punctuation.terminator.option.proto
+  }
+}

--- a/tests/syntax_test_proto3.proto
+++ b/tests/syntax_test_proto3.proto
@@ -1,0 +1,29 @@
+// SYNTAX TEST "Protobuf.sublime-syntax"
+syntax = "proto3";
+// <- keyword.other.syntax.proto
+//        ^^^^^^ string.quoted.double.proto
+
+import public "escape_dungeon/weapons.proto";
+// <- keyword.other.import.proto
+//     ^^^^^^ storage.modifier.proto
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.proto
+
+message Player {
+
+  required string name = 1;
+  // ^^^^^ storage.modifier.proto
+  //       ^^^^^^ support.type.proto
+  //              ^^^^ variable.other.field.proto
+  //                   ^ keyword.operator.assignment.proto
+  //                     ^ constant.numeric.proto
+  //                      ^ punctuation.terminator.proto
+
+  float health = 2;
+  // <- support.type.proto
+  //    ^^^^^^ variable.other.field.proto
+  //           ^ keyword.operator.assignment.proto
+  //             ^ constant.numeric.proto
+  //              ^ punctuation.terminator.proto
+}
+
+// Proto3 is really similar to Proto2 so no more tests here.


### PR DESCRIPTION
Features:

* Supports protobuffers serialized as text
* Follows scope conventions from http://www.sublimetext.com/docs/3/scope_naming.html
* Scoping for full types: `my_namespace.MyMessage`
* Precise scoping for embedded protos
* Handles rpc bodys: `rpc ... { option deadline = 5.0 }`
* Handles annotations for enum values

I wasn't aware of your syntax when I started writing this, so the diff doesn't look great.
I try to reorganize a bit my scopes to match your original definition.

This was originally proposed as a PR for the Default ST Packages, but @wbond thinks it should live in another package.
https://github.com/sublimehq/Packages/pull/1826