### PR TITLE
Capture single line comments correctly.

### DIFF
--- a/Protobuf.sublime-syntax
+++ b/Protobuf.sublime-syntax
@@ -62,7 +62,7 @@ contexts:
       scope: punctuation.definition.comment.begin.proto
       push:
         - meta_scope: comment.line.proto
-        - match: '$'
+        - match: $\n?
           pop: true
     - match: /\*
       scope: punctuation.definition.comment.proto

--- a/ProtobufText.sublime-syntax
+++ b/ProtobufText.sublime-syntax
@@ -38,7 +38,7 @@ contexts:
       scope: punctuation.definition.comment.begin.prototxt
       push:
         - meta_scope: comment.line.prototxt
-        - match: '$'
+        - match: $\n?
           pop: true
 
   field:


### PR DESCRIPTION
This uses the same match as the Go syntax highlighting to avoid showing an autocomplete box inside comments and improving the newline behaviour.