### PR TITLE
adds `protobuf` alias for supporting highlighters

### DIFF
--- a/Protobuf.sublime-syntax
+++ b/Protobuf.sublime-syntax
@@ -10,6 +10,7 @@
 name: Protocol Buffer
 file_extensions:
   - proto
+  - protobuf
   - protodevel
 scope: source.proto
 


### PR DESCRIPTION
I noticed that https://www.getzola.org/documentation/content/syntax-highlighting/ derives its shortcodes for syntax highlighting from this segment of the sublimetext definition.  The end-result of this is that it means that if someone uses `protobuf` for syntax highlighting, it won't work.

Since `proto` and `protobuf` are both very common usages for identifying the protobuf syntax, I don't know of any downsides to adding it here.