### PR TITLE
Add textproto extension

### DIFF
--- a/ProtobufText.sublime-syntax
+++ b/ProtobufText.sublime-syntax
@@ -14,6 +14,7 @@ file_extensions:
   - textpb
   - pbtxt
   - prototxt
+  - textproto
 scope: text.prototxt
 variables:
   stringEscape: '(?:\\(?:[''"\\/abfnrtv?]|[0-9]{3}|(?i:u|x)[0-9A-Fa-f]+))'


### PR DESCRIPTION
`.textproto` is now the official, canonical extension to use with the text format:

https://protobuf.dev/reference/protobuf/textformat-spec/#working-with-the-format-programmatically