### PR TITLE
Add canonical .txtpb to ProtobufText extensions

### DIFF
--- a/ProtobufText.sublime-syntax
+++ b/ProtobufText.sublime-syntax
@@ -9,6 +9,7 @@
 # .sublime-syntax reference: http://www.sublimetext.com/docs/3/syntax.html
 name: Protocol Buffer (TEXT)
 file_extensions:
+  - txtpb
   - pb.txt
   - proto.text
   - textpb


### PR DESCRIPTION
Per https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files:

> `.txtpb` is the canonical text format file extension and should be preferred to the alternatives. This suffix is preferred for its brevity and consistency with the official wire-format file extension `.binpb`. The legacy canonical extension `.textproto` still has widespread usage and tooling support. Some tooling also
supports the legacy extensions `.textpb` and `.pbtxt`. All other extensions besides the above are **strongly** discouraged; in particular, extensions such as `.protoascii` wrongly imply that text format is ascii-only, and others like `.pb.txt` are not recognized by common tooling.